### PR TITLE
Added get_power_status() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ braviarc.connect(pin, 'my_device_id', 'my device name')
 #check connection
 if braviarc.is_connected():
 
+  #get power status
+  power_status = braviarc.get_power_status()
+  print (power_status)
+
   #get playing info
   playing_content = braviarc.get_playing_info()
 

--- a/braviarc/braviarc.py
+++ b/braviarc/braviarc.py
@@ -179,6 +179,15 @@ class BraviaRC:
             return_value['startDateTime'] = playing_content_data.get('startDateTime')
         return return_value
 
+    def get_power_status(self):
+        """Get power status."""
+        return_value = {}
+        resp = self.bravia_req_json("sony/system", self._jdata_build("getPowerStatus", None))
+        if resp is not None and not resp.get('error'):
+            power_data = resp.get('result')[0]
+            return_value['status'] = power_data.get('status')
+        return return_value
+
     def _refresh_commands(self):
         resp = self.bravia_req_json("sony/system", self._jdata_build("getRemoteControllerInfo", None))
         if not resp.get('error'):

--- a/braviarc/braviarc.py
+++ b/braviarc/braviarc.py
@@ -185,7 +185,7 @@ class BraviaRC:
         resp = self.bravia_req_json("sony/system", self._jdata_build("getPowerStatus", None))
         if resp is not None and not resp.get('error'):
             power_data = resp.get('result')[0]
-            return_value['status'] = power_data.get('status')
+            return_value = power_data.get('status')
         return return_value
 
     def _refresh_commands(self):


### PR DESCRIPTION
Added a function so that you can check the power status of the device.

This is tested against a kd-43x8307c which is the only device I have. It's Android based and when you are running an App the get_playing_info() doesn't return any info.
