### PR TITLE
Call raise_for_status to raise HTTPError

### DIFF
--- a/braviarc/braviarc.py
+++ b/braviarc/braviarc.py
@@ -58,6 +58,7 @@ class BraviaRC:
         try:
             response = requests.post('http://'+self._host+'/sony/accessControl',
                                      data=authorization, headers=headers, timeout=TIMEOUT)
+            response.raise_for_status()
 
         except requests.exceptions.HTTPError as exception_instance:
             _LOGGER.error("[W] HTTPError: " + str(exception_instance))


### PR DESCRIPTION
HTTPErrors were not raised without raise_for_status, so when status code was e.g. 401, function returned True and is_connected also returned True.

Related issue from home-assistant:
https://github.com/home-assistant/home-assistant/issues/2744
