### PR TITLE
Handle error during connection in sleep mode.

### DIFF
--- a/braviarc/braviarc.py
+++ b/braviarc/braviarc.py
@@ -71,8 +71,10 @@ class BraviaRC:
 
         else:
             _LOGGER.info(json.dumps(response.json(), indent=4))
-            self._cookies = response.cookies
-            return True
+            resp = json.loads(response.content.decode('utf-8'))
+            if resp is not None and not resp.get('error'):
+                self._cookies = response.cookies
+                return True
 
         return False
 

--- a/braviarc/braviarc.py
+++ b/braviarc/braviarc.py
@@ -70,9 +70,9 @@ class BraviaRC:
             return False
 
         else:
-            _LOGGER.info(json.dumps(response.json(), indent=4))
-            resp = json.loads(response.content.decode('utf-8'))
-            if resp is not None and not resp.get('error'):
+            resp = response.json()
+            _LOGGER.info(json.dumps(resp, indent=4))
+            if resp is None or not resp.get('error'):
                 self._cookies = response.cookies
                 return True
 

--- a/braviarc/braviarc.py
+++ b/braviarc/braviarc.py
@@ -71,7 +71,7 @@ class BraviaRC:
 
         else:
             resp = response.json()
-            _LOGGER.info(json.dumps(resp, indent=4))
+            _LOGGER.debug(json.dumps(resp, indent=4))
             if resp is None or not resp.get('error'):
                 self._cookies = response.cookies
                 return True

--- a/braviarc/braviarc.py
+++ b/braviarc/braviarc.py
@@ -37,6 +37,22 @@ class BraviaRC:
         return ret
 
     def connect(self, pin, clientid, nickname):
+        """Connect to TV and get authentication cookie.
+
+        Parameters
+        ---------
+        pin: str
+            Pin code show by TV (or 0000 to get Pin Code).
+        clientid: str
+            Client ID.
+        nickname: str
+            Client human friendly name.
+
+        Returns
+        -------
+        bool
+            True if connected.
+        """
         authorization = json.dumps(
             {"method": "actRegister",
              "params": [{"clientid": clientid,


### PR DESCRIPTION
If TV is in sleep mode (not totally off) when I try to connect, its response  is :
```json
{"error":[7,"not power-on"],"id":1}
```
and there is not the necessary cookie for authentication but `is_connected()` return `True` 

I get sleep mode for few minutes when I turn the TV off.

