### PR TITLE
Add fallback TvPower command

### DIFF
--- a/braviarc/braviarc.py
+++ b/braviarc/braviarc.py
@@ -335,7 +335,10 @@ class BraviaRC:
         self._wakeonlan()
         # Try using the power on command incase the WOL doesn't work
         if self.get_power_status() != 'active':
-            self.send_req_ircc(self.get_command_code('TvPower'))
+            command = self.get_command_code('TvPower')
+            if command is None:
+                command = 'AAAAAQAAAAEAAAAuAw=='
+            self.send_req_ircc(command)
 
     def turn_off(self):
         """Turn off media player."""

--- a/braviarc/braviarc.py
+++ b/braviarc/braviarc.py
@@ -239,7 +239,7 @@ class BraviaRC:
 
     def _refresh_commands(self):
         resp = self.bravia_req_json("sony/system", self._jdata_build("getRemoteControllerInfo", None))
-        if not resp.get('error'):
+        if resp is not None and not resp.get('error'):
             self._commands = resp.get('result')[1]
         else:
             _LOGGER.error("JSON request error: " + json.dumps(resp, indent=4))


### PR DESCRIPTION
Should fix this error:

```
Traceback (most recent call last):
  File "/home/hass/venv/lib/python3.6/site-packages/homeassistant/helpers/service.py", line 224, in _handle_service_platform_call
    await getattr(entity, func)(**data)
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/hass/venv/lib/python3.6/site-packages/homeassistant/components/media_player/braviatv.py", line 309, in turn_on
    self._braviarc.turn_on()
  File "/home/hass/venv/lib/python3.6/site-packages/braviarc/braviarc.py", line 257, in turn_on
    self.send_req_ircc(self.get_command_code('TvPower'))
  File "/home/hass/venv/lib/python3.6/site-packages/braviarc/braviarc.py", line 229, in get_command_code
    self._refresh_commands()
  File "/home/hass/venv/lib/python3.6/site-packages/braviarc/braviarc.py", line 222, in _refresh_commands
    if not resp.get('error'):
AttributeError: 'NoneType' object has no attribute 'get'
```

Discussion https://github.com/home-assistant/home-assistant/issues/12577